### PR TITLE
Fix snarl coordinates

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -174,17 +174,25 @@ sample_hap_t get_sample_and_haplotype(const handlegraph::PathHandleGraph& graph,
 std::vector<path_range_t> get_coordinates_of_snarl(const handlegraph::PathPositionHandleGraph& graph, const bdsg::SnarlDistanceIndex& distance_index,
                                                    const handlegraph::net_handle_t& snarl, bool get_reference, std::string sample_name, bool get_all_paths) {
     std::vector<path_range_t> ranges;
+
+    // If we want the sample name first, then reference-sense next, check all ancestors for the sample_name, then all ancestors for the references-sense path.
+    // Save the reference from the first traversal so we don't have to traverse multiple times
+    std::vector<path_range_t> ref_ranges;
     // If a sample name is given, then always look for that first
     if (!sample_name.empty() || get_reference) {
         handlegraph::net_handle_t ancestor_snarl = snarl;
         while (!distance_index.is_root(ancestor_snarl)) {
             handlegraph::handle_t start_handle = distance_index.get_handle(distance_index.get_node_from_sentinel(distance_index.get_bound(ancestor_snarl, false, true)), &graph);
             handlegraph::handle_t end_handle = distance_index.get_handle(distance_index.get_node_from_sentinel(distance_index.get_bound(ancestor_snarl, true, true)), &graph);
+
+            // First, try to get the given sample name for this snarl
             if (!sample_name.empty()) {
                 ranges = get_coordinates_between_nodes(graph, start_handle, end_handle, false, sample_name, false);
             }
-            if (ranges.empty() && get_reference) {
-                ranges = get_coordinates_between_nodes(graph, start_handle, end_handle, true, "", false);
+            
+            // If that didn't work then get the reference-sense path for the lowest possible snarl
+            if (ranges.empty() && ref_ranges.empty() && get_reference) {
+                ref_ranges = get_coordinates_between_nodes(graph, start_handle, end_handle, true, "", false);
             }
             if (!ranges.empty()) {
                 return ranges;
@@ -192,6 +200,9 @@ std::vector<path_range_t> get_coordinates_of_snarl(const handlegraph::PathPositi
             // If this snarl isn't on the path we want, go up the snarl tree until we find something
             ancestor_snarl = distance_index.get_parent(distance_index.get_parent(ancestor_snarl));
         }
+    }
+    if (!ref_ranges.empty()) {
+        return ref_ranges;
     }
     handlegraph::handle_t start_handle = distance_index.get_handle(distance_index.get_node_from_sentinel(distance_index.get_bound(snarl, false, true)), &graph);
     handlegraph::handle_t end_handle = distance_index.get_handle(distance_index.get_node_from_sentinel(distance_index.get_bound(snarl, true, true)), &graph);

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -96,6 +96,7 @@ struct path_range_t {
 /// If get_reference is false, try to find coordinates on a path containing the given sample name, or if it fails, with any path.
 /// If get_reference is false and sample_name is empty and get_all_paths is true, return all coordinates for all paths
 /// For finding a specific path or reference, if the snarl is not on the desired path, then walk up the snarl tree to find an ancestor snarl on the path
+/// An ancestor also takes priority over a different path, so if there is a reference-sense path of the snarl, but sample_name on the ancestor, return sample_name on the ancestor
 std::vector<path_range_t> get_coordinates_of_snarl(const handlegraph::PathPositionHandleGraph& graph, const bdsg::SnarlDistanceIndex& distance_index,
                                                    const handlegraph::net_handle_t& snarl, bool get_reference, std::string sample_name, bool get_all_paths);
 

--- a/tests/unittest/utils_unit.cpp
+++ b/tests/unittest/utils_unit.cpp
@@ -213,9 +213,9 @@ TEST_CASE("Snarl coordinates deeply nested snarls with deletion in reference", "
     bdsg::PathPositionOverlayHelper overlay_helper;
     auto graph = overlay_helper.apply(&hash_graph);
 
-    handlegraph::net_handle_t snarl1 = distance_index.get_parent(distance_index.get_parent(distance_index.get_node_net_handle(5)));
-    handlegraph::net_handle_t snarl2 = distance_index.get_parent(distance_index.get_parent(distance_index.get_node_net_handle(4)));
-    handlegraph::net_handle_t snarl3 = distance_index.get_parent(distance_index.get_parent(distance_index.get_node_net_handle(3)));
+    handlegraph::net_handle_t snarl1 = distance_index.get_parent(distance_index.get_parent(distance_index.get_node_net_handle(6)));
+    handlegraph::net_handle_t snarl2 = distance_index.get_parent(distance_index.get_parent(distance_index.get_node_net_handle(5)));
+    handlegraph::net_handle_t snarl3 = distance_index.get_parent(distance_index.get_parent(distance_index.get_node_net_handle(4)));
 
     SECTION("reference with deletion") {
         vector<stoat::path_range_t> snarl1_paths = get_coordinates_of_snarl(*graph, distance_index, snarl1, true, "path0#0#0", false);
@@ -235,7 +235,7 @@ TEST_CASE("Snarl coordinates deeply nested snarls with deletion in reference", "
     }
 }
 
-TEST_CASE("Snarl coordinates deeply nested snarls with deletion in reference, but no reference sense", "[snarl_info]") {
+TEST_CASE("Snarl coordinates deeply nested snarls with no reference sense", "[snarl_info]") {
     /*
                       3
                     /   \
@@ -283,9 +283,9 @@ TEST_CASE("Snarl coordinates deeply nested snarls with deletion in reference, bu
     bdsg::PathPositionOverlayHelper overlay_helper;
     auto graph = overlay_helper.apply(&hash_graph);
 
-    handlegraph::net_handle_t snarl1 = distance_index.get_parent(distance_index.get_parent(distance_index.get_node_net_handle(5)));
-    handlegraph::net_handle_t snarl2 = distance_index.get_parent(distance_index.get_parent(distance_index.get_node_net_handle(4)));
-    handlegraph::net_handle_t snarl3 = distance_index.get_parent(distance_index.get_parent(distance_index.get_node_net_handle(3)));
+    handlegraph::net_handle_t snarl1 = distance_index.get_parent(distance_index.get_parent(distance_index.get_node_net_handle(6)));
+    handlegraph::net_handle_t snarl2 = distance_index.get_parent(distance_index.get_parent(distance_index.get_node_net_handle(5)));
+    handlegraph::net_handle_t snarl3 = distance_index.get_parent(distance_index.get_parent(distance_index.get_node_net_handle(4)));
 
     SECTION("reference with deletion") {
         vector<stoat::path_range_t> snarl1_paths = get_coordinates_of_snarl(*graph, distance_index, snarl1, true, "path0#0#0#0", false);
@@ -302,5 +302,118 @@ TEST_CASE("Snarl coordinates deeply nested snarls with deletion in reference, bu
         REQUIRE(std::get<0>(snarl3_coords) == "path0#0#0#0");
         REQUIRE(std::get<1>(snarl3_coords) == 1);
         REQUIRE(std::get<2>(snarl3_coords) == 1);
+    }
+}
+
+TEST_CASE("Snarl coordinates on given path instead of reference", "[snarl_info]") {
+    /*
+                      3
+                    /   \
+                   2 ----4  
+                 /         \
+               1  ----------5
+              /              \
+            0 ----------------6
+
+   */
+
+    bdsg::HashGraph hash_graph;
+
+    std::vector<std::string> sequences = { "C", "C", "C", "A", "T", "C", "A"};
+
+    std::vector<handlegraph::handle_t> nodes;
+    for (auto& seq : sequences) {
+        nodes.emplace_back(hash_graph.create_handle(seq));
+    }
+
+    hash_graph.create_edge(nodes[0], nodes[1]);
+    hash_graph.create_edge(nodes[0], nodes[6]);
+    hash_graph.create_edge(nodes[1], nodes[2]);
+    hash_graph.create_edge(nodes[1], nodes[5]);
+    hash_graph.create_edge(nodes[2], nodes[3]);
+    hash_graph.create_edge(nodes[2], nodes[4]);
+    hash_graph.create_edge(nodes[3], nodes[4]);
+    hash_graph.create_edge(nodes[4], nodes[5]);
+    hash_graph.create_edge(nodes[5], nodes[6]);
+
+    std::vector<std::vector<std::size_t>> paths_seqs = {{0, 1, 5, 6}, {0, 6}, {0, 1, 2, 3, 4, 5, 6}, {}};
+    std::vector<handlegraph::path_handle_t> paths;
+
+    for (int path_i = 0 ; path_i < paths_seqs.size() ; path_i++) {
+        if (path_i == 0) {
+            // Set first path with deletion as reference
+            paths.emplace_back(hash_graph.create_path_handle("path"+std::to_string(path_i)+"#0#0"));
+        } else {
+            paths.emplace_back(hash_graph.create_path_handle("path"+std::to_string(path_i)+"#0#0#0"));
+        }
+        for (size_t node_i : paths_seqs[path_i]) {
+            hash_graph.append_step(paths.back(), nodes[node_i]);
+        }
+    }
+
+    //// vg isn't included so the distance index can only be built from the command line
+    //hash_graph.serialize("../tests/graph_test/deeply_nested_snarl.hg");
+    //int built = system("vg index -j ../tests/graph_test/deeply_nested_snarl.dist ../tests/graph_test/deeply_nested_snarl.hg"); 
+
+    bdsg::SnarlDistanceIndex distance_index;
+    distance_index.deserialize("../tests/graph_test/deeply_nested_snarl.dist");
+    
+    //bdsg::HashGraph hash_graph;
+    //hash_graph.deserialize("../tests/graph_test/deeply_nested_snarl.hg");
+
+    bdsg::PathPositionOverlayHelper overlay_helper;
+    auto graph = overlay_helper.apply(&hash_graph);
+
+    handlegraph::net_handle_t snarl1 = distance_index.get_parent(distance_index.get_parent(distance_index.get_node_net_handle(6)));
+    handlegraph::net_handle_t snarl2 = distance_index.get_parent(distance_index.get_parent(distance_index.get_node_net_handle(5)));
+    handlegraph::net_handle_t snarl3 = distance_index.get_parent(distance_index.get_parent(distance_index.get_node_net_handle(4)));
+
+    SECTION("given sample with deletion") {
+        vector<stoat::path_range_t> snarl1_paths = get_coordinates_of_snarl(*graph, distance_index, snarl1, true, "path1#0#0#0", false);
+        REQUIRE(snarl1_paths.size() == 1);
+        std::tuple<std::string, size_t, size_t> snarl1_coords = get_name_and_offsets_of_snarl_path_range(*graph, snarl1_paths.front());
+        REQUIRE(std::get<0>(snarl1_coords) == "path1#0#0#0");
+        REQUIRE(std::get<1>(snarl1_coords) == 1);
+        REQUIRE(std::get<2>(snarl1_coords) == 1);
+
+        // Nested snarl off the reference
+        vector<stoat::path_range_t> snarl3_paths = get_coordinates_of_snarl(*graph, distance_index, snarl3, true, "path1#0#0#0", false);
+        REQUIRE(snarl3_paths.size() == 1);
+        std::tuple<std::string, size_t, size_t> snarl3_coords = get_name_and_offsets_of_snarl_path_range(*graph, snarl3_paths.front());
+        REQUIRE(std::get<0>(snarl3_coords) == "path1#0#0#0");
+        REQUIRE(std::get<1>(snarl3_coords) == 1);
+        REQUIRE(std::get<2>(snarl3_coords) == 1);
+    }
+    SECTION("reference") {
+        vector<stoat::path_range_t> snarl1_paths = get_coordinates_of_snarl(*graph, distance_index, snarl1, true, "", false);
+        REQUIRE(snarl1_paths.size() == 1);
+        std::tuple<std::string, size_t, size_t> snarl1_coords = get_name_and_offsets_of_snarl_path_range(*graph, snarl1_paths.front());
+        REQUIRE(std::get<0>(snarl1_coords) == "path0#0#0");
+        REQUIRE(std::get<1>(snarl1_coords) == 1);
+        REQUIRE(std::get<2>(snarl1_coords) == 3);
+
+        // Nested snarl off the reference
+        vector<stoat::path_range_t> snarl3_paths = get_coordinates_of_snarl(*graph, distance_index, snarl3, true, "", false);
+        REQUIRE(snarl3_paths.size() == 1);
+        std::tuple<std::string, size_t, size_t> snarl3_coords = get_name_and_offsets_of_snarl_path_range(*graph, snarl3_paths.front());
+        REQUIRE(std::get<0>(snarl3_coords) == "path0#0#0");
+        REQUIRE(std::get<1>(snarl3_coords) == 2);
+        REQUIRE(std::get<2>(snarl3_coords) == 2);
+    }
+    SECTION("given sample not on snarl") {
+        vector<stoat::path_range_t> snarl1_paths = get_coordinates_of_snarl(*graph, distance_index, snarl1, true, "path3#0#0#0", false);
+        REQUIRE(snarl1_paths.size() == 1);
+        std::tuple<std::string, size_t, size_t> snarl1_coords = get_name_and_offsets_of_snarl_path_range(*graph, snarl1_paths.front());
+        REQUIRE(std::get<0>(snarl1_coords) == "path0#0#0");
+        REQUIRE(std::get<1>(snarl1_coords) == 1);
+        REQUIRE(std::get<2>(snarl1_coords) == 3);
+
+        // Nested snarl off the reference
+        vector<stoat::path_range_t> snarl3_paths = get_coordinates_of_snarl(*graph, distance_index, snarl3, true, "path3#0#0#0", false);
+        REQUIRE(snarl3_paths.size() == 1);
+        std::tuple<std::string, size_t, size_t> snarl3_coords = get_name_and_offsets_of_snarl_path_range(*graph, snarl3_paths.front());
+        REQUIRE(std::get<0>(snarl3_coords) == "path0#0#0");
+        REQUIRE(std::get<1>(snarl3_coords) == 2);
+        REQUIRE(std::get<2>(snarl3_coords) == 2);
     }
 }


### PR DESCRIPTION
Make snarl coordinates walk up the snarl tree to find given reference name instead of defaulting to the reference-sense path
