### PR TITLE
remove prefix on snarl intermediate file input and output of stoat vcf

### DIFF
--- a/src/snarl_data_collection.cpp
+++ b/src/snarl_data_collection.cpp
@@ -962,7 +962,7 @@ The 9th item is all of the sequences, comma separated. "." if not present
 The remaining items are the allele number for each sample. "." if the sample is not present in the snarl
 
 */
-void SnarlDataCollection::write_snarl_data_collection_header(stoat::Writer& out_writer) const {
+void SnarlDataCollection::write_snarl_data_collection_header(stoat::Writer& out_writer, const std::string& remove_prefix_str) const {
     std::stringstream outstream;
     
     // Write the header
@@ -974,10 +974,17 @@ void SnarlDataCollection::write_snarl_data_collection_header(stoat::Writer& out_
 
     // Next will be a list of reference path names.
     outstream << "#REFS" << std::endl;
-    for (const auto& ref : reference_names) {
-        outstream << "#" << ref << std::endl;
+    if (remove_prefix_str != "") { // case where remove prefix is specified
+        for (const auto& ref : reference_names) {
+            std::string reference_str = stoat::remove_prefix(ref, remove_prefix_str); 
+            outstream << "#" << reference_str << std::endl;
+        }
+    } else {
+        for (const auto& ref : reference_names) {
+            outstream << "#" << ref << std::endl;
+        }
     }
-    
+
     //Finally the snarls
     // Start with a header that will contain the names of all samples
     outstream << "#SNARLS" << std::endl;
@@ -1073,8 +1080,8 @@ void SnarlDataCollection::write_snarl_data_line(stoat::Writer& out_writer, const
     }
 }
 
-void SnarlDataCollection::write_snarl_data_collection(stoat::Writer& out_writer) const {
-    write_snarl_data_collection_header(out_writer);
+void SnarlDataCollection::write_snarl_data_collection(stoat::Writer& out_writer, const std::string& remove_prefix_str) const {
+    write_snarl_data_collection_header(out_writer, remove_prefix_str);
 
     // Now write the snarls, one per line
     for (const snarl_info_internal_t& snarl_data : all_snarl_data) {
@@ -1084,7 +1091,7 @@ void SnarlDataCollection::write_snarl_data_collection(stoat::Writer& out_writer)
     return;
 }
 
-void SnarlDataCollection::load_snarl_data_collection_header(stoat::Reader& in_reader) {
+void SnarlDataCollection::load_snarl_data_collection_header(stoat::Reader& in_reader, const std::string& remove_prefix_str) {
 
     // Clear anything that has already been filled in, since we want it to match what was in the file
     all_snarl_data.clear();
@@ -1157,10 +1164,14 @@ void SnarlDataCollection::load_snarl_data_collection_header(stoat::Reader& in_re
     
     // Get the reference path names from the file
     while (line != "#SNARLS") {
-        std::string ref (line.begin()+1, line.end());
+        std::string ref(line.begin()+1, line.end());
+        if (remove_prefix_str != "") {
+            ref = stoat::remove_prefix(ref, remove_prefix_str);
+        }
         reference_names.emplace_back(std::move(ref));
         in_reader.getline(line);
     }
+
 
     // The next header is  "#START_NODE\tEND_NODE\tREF\tSTART_OFFSET\tEND_OFFSET\tDEPTH\tALLELE_LENGTHS\tWALKS\tSEQUENCES", plus all of the sample/haplotypes
     in_reader.getline(line);
@@ -1283,8 +1294,8 @@ SnarlDataCollection::snarl_info_internal_t SnarlDataCollection::load_snarl_data_
     return snarl_info;
 }
 
-void SnarlDataCollection::load_snarl_data_collection(stoat::Reader& in_reader, const bool header_only) {
-    load_snarl_data_collection_header(in_reader);
+void SnarlDataCollection::load_snarl_data_collection(stoat::Reader& in_reader, const std::string remove_prefix_str, const bool header_only) {
+    load_snarl_data_collection_header(in_reader, remove_prefix_str);
 
     if (!header_only) {
         std::string line;

--- a/src/snarl_data_collection.cpp
+++ b/src/snarl_data_collection.cpp
@@ -396,7 +396,7 @@ void SnarlDataCollection::add_alleles_by_sample(const std::function<std::vector<
 
 }
 
-void SnarlDataCollection::genotype_snarls_by_chr_from_vcf(std::vector<std::string>& sample_names, stoat_vcf::VCFParser& vcf_parser) {
+void SnarlDataCollection::genotype_snarls_by_chr_from_vcf(std::vector<std::string>& sample_names, stoat_vcf::VCFParser& vcf_parser, const std::string& remove_prefix_str) {
     // we'll use this edge matrix object
     // TODO find the vector of sample names from the VCF header?
     stoat_vcf::EdgeBySampleMatrix edge_matrix(sample_names, 0);
@@ -424,7 +424,11 @@ void SnarlDataCollection::genotype_snarls_by_chr_from_vcf(std::vector<std::strin
     // read the VCF by chunk, build the edge matrix and genotype each snarl
     // We assume that the vcf parser has read the header and is now ready to go through the snarls
     std::string chr = vcf_parser.get_next_chromosome_name();
-    
+
+    if (remove_prefix_str != "") {
+        chr = stoat::remove_prefix(chr, remove_prefix_str);
+    }
+
     // Go through to the end of the VCF. Chunk by chromosome 
     while (chr != "") {
 
@@ -435,8 +439,13 @@ void SnarlDataCollection::genotype_snarls_by_chr_from_vcf(std::vector<std::strin
 
             // Just skip to the next one without doing anything
             vcf_parser.skip_to_next_chromosome(chr);
-            
+
             chr = vcf_parser.get_next_chromosome_name();
+
+            if (remove_prefix_str != "") {
+                chr = stoat::remove_prefix(chr, remove_prefix_str);
+            }
+
             if (chr == "") {
                 // If we've reached the end of the file, return
                 return;
@@ -452,7 +461,7 @@ void SnarlDataCollection::genotype_snarls_by_chr_from_vcf(std::vector<std::strin
         // prepare the edge matrix for this chromosome by reading the VCF
         // this will read to the end of this chr
         edge_matrix.load_vcf_chunk(vcf_parser, chr);
-        
+
         auto timer_end_matrix = std::chrono::high_resolution_clock::now();
         stoat::LOG_INFO("Edge matrix construction for chr " + chr + " : " + std::to_string(std::chrono::duration<double>(timer_end_matrix - timer_start_chr).count()) + " s");
 
@@ -466,7 +475,7 @@ void SnarlDataCollection::genotype_snarls_by_chr_from_vcf(std::vector<std::strin
                     allele_idx.at(samp_hap_idx) = al_idx;
                 }
             }
-            
+
             return allele_idx;
         }, chr);
 

--- a/src/snarl_data_collection.cpp
+++ b/src/snarl_data_collection.cpp
@@ -345,6 +345,22 @@ void SnarlDataCollection::fill_in_snarl_info(const handlegraph::PathPositionHand
     }
 
 }
+
+void SnarlDataCollection::remove_prefix_reference_names(const std::string& remove_prefix_str) {
+    
+    if (!remove_prefix_str.empty()) {
+
+        std::vector<std::string> new_reference_names;
+        new_reference_names.reserve(reference_names.size());
+
+        for (const auto& ref : reference_names) {
+            new_reference_names.push_back(remove_prefix(ref, remove_prefix_str));
+        }
+
+        reference_names = new_reference_names;
+    }
+}
+
 void SnarlDataCollection::add_alleles_by_sample(const std::function<std::vector<size_t>(const snarl_info_t& snarl_data, 
                                                                                         const std::vector<stoat::sample_hap_t>& all_sample_haplotypes)>& find_alleles_by_sample,
                                                 std::string chr){
@@ -396,7 +412,7 @@ void SnarlDataCollection::add_alleles_by_sample(const std::function<std::vector<
 
 }
 
-void SnarlDataCollection::genotype_snarls_by_chr_from_vcf(std::vector<std::string>& sample_names, stoat_vcf::VCFParser& vcf_parser, const std::string& remove_prefix_str) {
+void SnarlDataCollection::genotype_snarls_by_chr_from_vcf(std::vector<std::string>& sample_names, stoat_vcf::VCFParser& vcf_parser) {
     // we'll use this edge matrix object
     // TODO find the vector of sample names from the VCF header?
     stoat_vcf::EdgeBySampleMatrix edge_matrix(sample_names, 0);
@@ -425,10 +441,6 @@ void SnarlDataCollection::genotype_snarls_by_chr_from_vcf(std::vector<std::strin
     // We assume that the vcf parser has read the header and is now ready to go through the snarls
     std::string chr = vcf_parser.get_next_chromosome_name();
 
-    if (remove_prefix_str != "") {
-        chr = stoat::remove_prefix(chr, remove_prefix_str);
-    }
-
     // Go through to the end of the VCF. Chunk by chromosome 
     while (chr != "") {
 
@@ -441,10 +453,6 @@ void SnarlDataCollection::genotype_snarls_by_chr_from_vcf(std::vector<std::strin
             vcf_parser.skip_to_next_chromosome(chr);
 
             chr = vcf_parser.get_next_chromosome_name();
-
-            if (remove_prefix_str != "") {
-                chr = stoat::remove_prefix(chr, remove_prefix_str);
-            }
 
             if (chr == "") {
                 // If we've reached the end of the file, return

--- a/src/snarl_data_collection.hpp
+++ b/src/snarl_data_collection.hpp
@@ -128,7 +128,7 @@ class SnarlDataCollection {
     // fill in the genotypes of the snarls based on the edge matrix built on a VCF stream
     // the VCF is read and parsed by chromosome
     // The vcf parser is assumed to have loaded the header and be pointing to the start of the actual records
-    void genotype_snarls_by_chr_from_vcf(std::vector<std::string>& sample_names, stoat_vcf::VCFParser& vcf_parser);
+    void genotype_snarls_by_chr_from_vcf(std::vector<std::string>& sample_names, stoat_vcf::VCFParser& vcf_parser, const std::string& remove_prefix_str);
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     //////////////////////////////////////////// Private data members

--- a/src/snarl_data_collection.hpp
+++ b/src/snarl_data_collection.hpp
@@ -128,7 +128,10 @@ class SnarlDataCollection {
     // fill in the genotypes of the snarls based on the edge matrix built on a VCF stream
     // the VCF is read and parsed by chromosome
     // The vcf parser is assumed to have loaded the header and be pointing to the start of the actual records
-    void genotype_snarls_by_chr_from_vcf(std::vector<std::string>& sample_names, stoat_vcf::VCFParser& vcf_parser, const std::string& remove_prefix_str);
+    void genotype_snarls_by_chr_from_vcf(std::vector<std::string>& sample_names, stoat_vcf::VCFParser& vcf_parser);
+
+    // remove from reference_names a const prefix name 
+    void remove_prefix_reference_names(const std::string& remove_prefix_str);
 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     //////////////////////////////////////////// Private data members

--- a/src/snarl_data_collection.hpp
+++ b/src/snarl_data_collection.hpp
@@ -92,12 +92,12 @@ class SnarlDataCollection {
 
 
         /// Write the collection of snarls to the given file
-        void write_snarl_data_collection(Writer& out_writer) const;
+        void write_snarl_data_collection(Writer& out_writer, const std::string& remove_prefix_str="") const;
         
         /// Load the collection of snarls from the given file
         /// Warn if the allele_size_limit or snarl_child_limit of the file are less permissive than this SnarlDataCollection
         /// also a mode to load just the header used to reuse the same sample_to_index for other objects and then run snarl file line by line (although it means loading the sample_to_index map twice technically)
-       void load_snarl_data_collection(stoat::Reader& in_reader, const bool header_only = false); 
+       void load_snarl_data_collection(stoat::Reader& in_reader, const std::string remove_prefix_str="", const bool header_only = false); 
 
         std::unordered_map<std::string, size_t> get_sample_to_index_copy() const;
     
@@ -226,7 +226,7 @@ class SnarlDataCollection {
         //////////////////// Helper functions for writing and loading stuff from files
 
         /// Write just the header of the collection of snarls to the given file
-        void write_snarl_data_collection_header(Writer& out_writer) const;
+        void write_snarl_data_collection_header(Writer& out_writer, const std::string& remove_prefix_str="") const;
 
         /// Write just one snarl from the collection
         void write_snarl_data_line(Writer& out_writer, const snarl_info_internal_t& snarl_info) const;
@@ -234,7 +234,7 @@ class SnarlDataCollection {
                                     const std::vector<std::string>* snarl_sequences, const allele_by_sample_t* alleles_by_sample) const;
 
         /// Given a stream to the start of the file, load just the header. The stream will be advanced to point to the beginning of the snarl records
-    void load_snarl_data_collection_header(stoat::Reader& in_reader);
+        void load_snarl_data_collection_header(stoat::Reader& in_reader, const std::string& remove_prefix_str="");
 
         /// Given a string representing a line in the file, load one snarl_info_internal_t
         /// This assumes that load_snarl_collection_header() has already been called

--- a/src/subcommand/test.cpp
+++ b/src/subcommand/test.cpp
@@ -193,7 +193,7 @@ int main_stoat_test(int argc, char* argv[]) {
     } else {
         snarl_reader.reset(new StdReader(genotype_path));
     }
-    snarl_collection.load_snarl_data_collection(*snarl_reader, true);
+    snarl_collection.load_snarl_data_collection(*snarl_reader, "", true);
     snarl_reader->close();
 
     //////////////////////////////////////// Go through the genotypes and test against the phenotype    

--- a/src/subcommand/vcf.cpp
+++ b/src/subcommand/vcf.cpp
@@ -37,6 +37,7 @@ void print_help_vcf() {
               << "  -s, --snarl FILE                Path to the snarl file\n"
               << "  -R, --reference-file FILE       Path to the chromosome reference file, one path name per line (optional)\n"
               << "  -r, --reference-prefix NAME     The prefix of paths to be used as references. These paths must be REFERENCE- or GENERIC-sense paths (check with vg paths -M). (optional)\n"
+              << "  -p, --remove-prefix STR         Remove the given prefix from the reference names in the snarl decomposition file (optional)\n"
               << "  -i, --children INT              Max number of children per snarl in decomposition [50]\n"
               << "  -y, --cycle INT                 Max number of authorized cycles in snarl decomposition [1]\n"
               << "  -l, --path-length INT           Max number of nodes in paths during snarl decomposition [50]\n"
@@ -52,7 +53,7 @@ void print_help_vcf() {
 int main_stoat_vcf(int argc, char* argv[]) {
     
     // Declare variables to hold argument values
-    std::string vcf_path, snarl_path, graph_path, dist_path, reference_path, reference_prefix;
+    std::string vcf_path, snarl_path, graph_path, dist_path, reference_path, reference_prefix, remove_prefix_str;
 
     size_t cycle_threshold = 1;
     size_t children_threshold = 50;
@@ -75,6 +76,7 @@ int main_stoat_vcf(int argc, char* argv[]) {
         {"dist", required_argument, 0, 'd'},
         {"reference-file", required_argument, 0, 'R'},
         {"reference-prefix", required_argument, 0, 'r'},
+        {"remove-prefix", required_argument, 0, 'p'},
         {"children", required_argument, 0, 'i'},
         {"cycle", required_argument, 0, 'y'},
         {"path-length", required_argument, 0, 'l'},
@@ -88,7 +90,7 @@ int main_stoat_vcf(int argc, char* argv[]) {
         {0, 0, 0, 0}
     };
 
-    while ((c = getopt_long(argc, argv, "v:s:g:d:R:i:y:l:ft:V:o:uah", long_options, nullptr)) != -1) {
+    while ((c = getopt_long(argc, argv, "v:s:g:d:R:r:p:i:y:l:ft:V:o:uah", long_options, nullptr)) != -1) {
         switch (c) {
             case 'v': vcf_path = optarg; stoat_vcf::check_file(vcf_path); break;
             case 's': snarl_path = optarg; stoat_vcf::check_file(snarl_path); break;
@@ -96,6 +98,7 @@ int main_stoat_vcf(int argc, char* argv[]) {
             case 'd': dist_path = optarg; stoat_vcf::check_file(dist_path); break;
             case 'R': reference_path = optarg; stoat_vcf::check_file(reference_path); break;
             case 'r': reference_prefix = optarg; break;
+            case 'p': remove_prefix_str = optarg; break;
             case 'a': ascii = true; break;
             case 'i':
                 children_threshold = std::stoi(optarg);
@@ -218,7 +221,7 @@ int main_stoat_vcf(int argc, char* argv[]) {
             snarl_reader.reset(new StdReader(snarl_path));
         }
         auto start_load_timer = std::chrono::high_resolution_clock::now();
-        snarl_collection.load_snarl_data_collection(*snarl_reader);
+        snarl_collection.load_snarl_data_collection(*snarl_reader, remove_prefix_str);
         auto end_load_timer = std::chrono::high_resolution_clock::now();
         stoat::LOG_INFO("Loading snarl information took " + std::to_string(std::chrono::duration<double>(end_load_timer - start_load_timer).count()) + " s");
         snarl_reader->close();
@@ -352,7 +355,7 @@ int main_stoat_vcf(int argc, char* argv[]) {
         stoat::LOG_INFO("Writing genotypes in " + genotype_path);
         // JEAN would reduce memory to write the collection while genotyping the snarls, one chr at a time, appending to the output file (or in separate chr files).
         auto start_writegt_timer = std::chrono::high_resolution_clock::now();
-        snarl_collection.write_snarl_data_collection(*gt_writer);
+        snarl_collection.write_snarl_data_collection(*gt_writer, remove_prefix_str);
         gt_writer->close();
         auto end_writegt_timer = std::chrono::high_resolution_clock::now();
         stoat::LOG_INFO("Writing genotypes took " + std::to_string(std::chrono::duration<double>(end_writegt_timer - start_writegt_timer).count()) + " s");

--- a/src/subcommand/vcf.cpp
+++ b/src/subcommand/vcf.cpp
@@ -332,7 +332,7 @@ int main_stoat_vcf(int argc, char* argv[]) {
         std::vector<std::string> list_samples = vcf_parser.initialize_parser(vcf_path);
 
         // retrieve genotypes one chromosome at a time
-        snarl_collection.genotype_snarls_by_chr_from_vcf(list_samples, vcf_parser);
+        snarl_collection.genotype_snarls_by_chr_from_vcf(list_samples, vcf_parser, remove_prefix_str);
 
         // We are done reading through the vcf file so close it
         vcf_parser.close_vcf();
@@ -355,7 +355,7 @@ int main_stoat_vcf(int argc, char* argv[]) {
         stoat::LOG_INFO("Writing genotypes in " + genotype_path);
         // JEAN would reduce memory to write the collection while genotyping the snarls, one chr at a time, appending to the output file (or in separate chr files).
         auto start_writegt_timer = std::chrono::high_resolution_clock::now();
-        snarl_collection.write_snarl_data_collection(*gt_writer, remove_prefix_str);
+        snarl_collection.write_snarl_data_collection(*gt_writer);
         gt_writer->close();
         auto end_writegt_timer = std::chrono::high_resolution_clock::now();
         stoat::LOG_INFO("Writing genotypes took " + std::to_string(std::chrono::duration<double>(end_writegt_timer - start_writegt_timer).count()) + " s");

--- a/src/subcommand/vcf.cpp
+++ b/src/subcommand/vcf.cpp
@@ -302,6 +302,8 @@ int main_stoat_vcf(int argc, char* argv[]) {
             !only_prepare_snarls // Keep the snarls in the collection? True if we're going to genotype
             ); 
 
+        snarl_collection.remove_prefix_reference_names(remove_prefix_str);
+
         // done saving the snarls, close the writer
         snarl_writer->close();
 
@@ -332,7 +334,7 @@ int main_stoat_vcf(int argc, char* argv[]) {
         std::vector<std::string> list_samples = vcf_parser.initialize_parser(vcf_path);
 
         // retrieve genotypes one chromosome at a time
-        snarl_collection.genotype_snarls_by_chr_from_vcf(list_samples, vcf_parser, remove_prefix_str);
+        snarl_collection.genotype_snarls_by_chr_from_vcf(list_samples, vcf_parser);
 
         // We are done reading through the vcf file so close it
         vcf_parser.close_vcf();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -36,6 +36,16 @@ double string_to_pvalue(const std::string& p1) {
     }
 }
 
+std::string remove_prefix(const std::string& str, const std::string& prefix) {
+    if (str.size() <= prefix.size()) { // avoiding out-of-range errors or returning an empty string
+        return str;
+    }
+    if (str.rfind(prefix, 0) == 0) { // Check if 'str' starts with 'prefix'
+        return str.substr(prefix.length()); // Remove the prefix
+    }
+    return str; // Return the original string if it doesn't start with the prefix
+}
+
 // Adjust p-values using Hochberg correction
 std::pair<double, size_t> adjusted_hochberg(const std::vector<double>& p_values) {
     size_t m = p_values.size();

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -25,6 +25,7 @@ std::string set_precision(const double& value);
 
 bool is_na(const std::string& s);
 double string_to_pvalue(const std::string& p1);
+std::string remove_prefix(const std::string& str, const std::string& prefix);
 
 std::pair<double, size_t> adjusted_hochberg(const std::vector<double>& p_values);
 

--- a/tests/unittest/utils_unit.cpp
+++ b/tests/unittest/utils_unit.cpp
@@ -31,6 +31,17 @@ TEST_CASE("string_to_pvalue converts valid p-values or returns 1.0 for NA") {
     REQUIRE(stoat::string_to_pvalue("") == 1.0);
 }
 
+TEST_CASE("remove_prefix cases") {
+
+    REQUIRE(remove_prefix("", "foo") == "");
+    REQUIRE(remove_prefix("foo", "") == "foo");
+    REQUIRE(remove_prefix("$$#$value", "$$") == "#$value");
+
+    std::string prefix = "prefix_";
+    std::string long_str = prefix + std::string(1000, 'a');
+    REQUIRE(remove_prefix(long_str, prefix) == std::string(1000, 'a'));
+}
+
 TEST_CASE("adjusted_hochberg basic example") {
     std::vector<double> raw = {0.02, 0.15, 0.03, 0.001, 0.25, 0.05};
     std::pair<double, size_t> expected = {0.006, 3};


### PR DESCRIPTION
## PR Log Entry
Whoever merges this PR should copy the following bullet points to the [PR Log](https://github.com/Pa-Tou/stoat/wiki/PR-Log):

 * Summary of the PR
Linked to this issue: https://github.com/Pa-Tou/stoat/issues/36
Add new option on stoat vcf that remove the snarl chromosome prefix for both case : 
   - stoat vcf snarl decomposition process
   - stoat vcf genotyping process

## Description
