### PR TITLE
Fix getopt_long option for 'r' in vcf.cpp

### DIFF
--- a/src/subcommand/vcf.cpp
+++ b/src/subcommand/vcf.cpp
@@ -88,7 +88,7 @@ int main_stoat_vcf(int argc, char* argv[]) {
         {0, 0, 0, 0}
     };
 
-    while ((c = getopt_long(argc, argv, "v:s:g:d:R:i:y:l:ft:V:o:uah", long_options, nullptr)) != -1) {
+    while ((c = getopt_long(argc, argv, "v:s:g:d:R:r:i:y:l:ft:V:o:uah", long_options, nullptr)) != -1) {
         switch (c) {
             case 'v': vcf_path = optarg; stoat_vcf::check_file(vcf_path); break;
             case 's': snarl_path = optarg; stoat_vcf::check_file(snarl_path); break;


### PR DESCRIPTION
## PR Log Entry
Whoever merges this PR should copy the following bullet points to the [PR Log](https://github.com/Pa-Tou/stoat/wiki/PR-Log):

 * Summary of the PR
Fix missing r from getopt_long vcf 

## Description
