### PR TITLE
Mask samples missing from the phenotype/covariate files

### DIFF
--- a/src/arg_parser.cpp
+++ b/src/arg_parser.cpp
@@ -173,10 +173,11 @@ stoat::BinaryPhenotypeTable* parse_binary_pheno_table(const std::string& file_pa
         }
     }
 
-    // samples in the index but without a phenotype
+    // samples in the index but not in the phenotype file are marked as missing
     for (const auto& [sample, idx] : sample_to_index) {
         if (binary_pheno.find(sample) == binary_pheno.end()) {
             ++missing_in_pheno;
+            output_table->add_missing_sample_index(idx);
         }
     }
 
@@ -273,10 +274,11 @@ stoat::QuantitativePhenotypeTable* parse_quantitative_pheno_table(const std::str
         }
     }
 
-    // genotype samples missing phenotype
+    // samples in the index but not in the phenotype file are marked as missing
     for (const auto& [sample, idx] : sample_to_index) {
         if (quantitative_pheno.find(sample) == quantitative_pheno.end()) {
             ++missing_in_pheno;
+            output_table->add_missing_sample_index(idx);
         }
     }
 
@@ -412,9 +414,11 @@ stoat::GeneExpressionTable* parse_gene_expression_table(const std::string& gene_
         }
     }
 
+    // samples in the index but not in the expression file are marked as missing
     for (const auto& [sample, idx] : sample_to_index) {
         if (ge_map.find(sample) == ge_map.end()) {
             ++missing_in_expression;
+            output_table->add_missing_sample_index(idx);
         }
     }
 
@@ -565,9 +569,11 @@ stoat::CovariateTable* parse_covariate_table(
         }
     }
 
+    // samples in the index but not in the covariable file are marked as missing
     for (const auto& [sample, idx] : sample_to_index) {
         if (covariate_map.find(sample) == covariate_map.end()) {
             ++genotype_missing_covars;
+            output_table->add_missing_sample_index(idx);
         }
     }
 

--- a/src/feature_tables.cpp
+++ b/src/feature_tables.cpp
@@ -76,6 +76,25 @@ const std::unordered_map<std::string, size_t>& FeatureBySampleTable<ValueType>::
     return sample_to_index;
 }
 
+template<class ValueType>
+void FeatureBySampleTable<ValueType>::add_missing_sample_index(size_t sample_idx) {
+    missing_sample_index.insert(sample_idx);
+}
+    
+template<class ValueType>
+size_t FeatureBySampleTable<ValueType>::mask_sample_index(std::vector<bool>& row_mask) const {
+    size_t n_masked = 0;
+    for (size_t samp_idx : missing_sample_index) {
+        // if that sample was not already masked, we'll mask it so tally it
+        if (!row_mask.at(samp_idx)) {
+            n_masked++;
+        }
+        // mask that sample
+        row_mask.at(samp_idx) = true;
+    }
+    return n_masked;
+}
+    
 // Getter for CategoricalFeatureBySampleTable
 template<class ValueType>
 ValueType CategoricalFeatureBySampleTable<ValueType>::get_value_for_sample_and_feature(const std::string& sample, const std::string& feature) const {
@@ -206,6 +225,9 @@ GenotypeTable::GenotypeTable(const std::unordered_map<std::string, size_t>& samp
     // init the column with the total allele counts
     total_allele_counts_per_sample = std::vector<double>(n_samples, 0);
     use_total_ac = false;
+
+    // init info about the phenotype being linked already
+    linked_phenotype = false;
 }
     
 void GenotypeTable::clear() {
@@ -296,11 +318,13 @@ size_t GenotypeTable::get_allele_count() const {
 void GenotypeTable::link_to_binary_phenotype(const BinaryPhenotypeTable& phenotype) {
     b_phenotype = &phenotype;
     is_binary_pheno = true;
+    linked_phenotype = true;
 }
 
 void GenotypeTable::link_to_quantitative_phenotype(const QuantitativePhenotypeTable& phenotype) {
     q_phenotype = &phenotype;
     is_binary_pheno = false;
+    linked_phenotype = true;
 }
 
 void GenotypeTable::link_to_covariates(const CovariateTable& in_covariates) {
@@ -320,7 +344,23 @@ void GenotypeTable::remove_noncovered_samples() {
             n_active_samples--;
         }
     }
-    // JEAN TODO check that this is called before the test/regression
+
+    // mask samples that don't have a phenotype
+    size_t masked_samples = 0;
+    if (linked_phenotype) {
+        if (is_binary_pheno) {
+            masked_samples = b_phenotype->mask_sample_index(row_mask);
+        } else {
+            masked_samples = q_phenotype->mask_sample_index(row_mask);
+        }
+        n_active_samples -= masked_samples;
+    }
+    
+    // mask samples that don't have a covariate information
+    if (n_covariates > 0) {
+        masked_samples = covariates->mask_sample_index(row_mask);
+        n_active_samples -= masked_samples;
+    }
 }
 
 void GenotypeTable::remove_constant_predictors() {

--- a/src/feature_tables.hpp
+++ b/src/feature_tables.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <Eigen/Dense>
 #include <Eigen/Core>
 
@@ -70,12 +71,22 @@ class FeatureBySampleTable {
     // return a pointer to the sample->index map
     const std::unordered_map<std::string, size_t>& get_sample_to_index() const;
 
+    // add a sample index that has no value
+    void add_missing_sample_index(size_t sample_idx);
+    
+    // mask samples with no value in the input mask vector
+    // returns the number of samples that were masked
+    size_t mask_sample_index(std::vector<bool>& row_mask) const;
+    
     protected:
     // Map from the samples that we have features for to their index in values_per_sample
     const std::unordered_map<std::string, size_t>& sample_to_index;
 
     // The values of the feature per sample in sample_to_index
     std::vector<ValueType> values_per_sample;
+
+    // to remember the sample indexes that are absent
+    std::unordered_set<size_t> missing_sample_index;
 };
 
 // template<class ValueType>
@@ -253,6 +264,7 @@ protected:
 
     // remember if the phenotype values are bool or double (maybe a better way?)
     bool is_binary_pheno;
+    bool linked_phenotype;
     
     // a mask for the columns/rows (which ones to exclude)
     std::vector<bool> col_mask;

--- a/tests/unittest/feature_tables_unit.cpp
+++ b/tests/unittest/feature_tables_unit.cpp
@@ -386,7 +386,7 @@ TEST_CASE( "Combined GenotypeTable", "[table]" ) {
         geno.link_to_quantitative_phenotype(pheno);
 
         // remove non-variable allele, e.g. absent in both groups
-        geno.remove_noncovered_samples();    
+        geno.remove_noncovered_samples();
         geno.remove_constant_predictors();
         
         REQUIRE(geno.passes_filters(0, 0));
@@ -395,5 +395,73 @@ TEST_CASE( "Combined GenotypeTable", "[table]" ) {
         REQUIRE(!geno.passes_filters(0, 6));
     }
 
+}
+
+TEST_CASE( "Combined GenotypeTable with missing samples", "[table]" ) {
+
+
+    //     A0 A1 A2 A3
+    // S1 {1, 0, 1, 1}
+    // S2 {1, 0, 1, 1}
+    // S3 {1, 0, 0, 0}
+    // S4 {1, 0, 0, 0}
+    // S5 {0, 0, 1, 1}
+
+    std::unordered_map<std::string, size_t> sample_to_index = {{"S1", 0}, {"S2", 1}, {"S3", 2},
+                                                               {"S4", 3}, {"S5", 4}};
+    stoat::GenotypeTable table(sample_to_index, 4);
+    table.increment_count(0, 0);
+    table.increment_count(0, 2);
+    table.increment_count(0, 3);
+    table.increment_count(1, 0);
+    table.increment_count(1, 2);
+    table.increment_count(1, 3);
+    table.increment_count(2, 0);
+    table.increment_count(3, 0);
+    table.increment_count(4, 2);
+    table.increment_count(4, 3);
+
+
+    SECTION("Table is the right size") {
+        REQUIRE(table.get_n_active_alleles() == 4);
+        REQUIRE(table.get_n_active_samples() == 5);
+    }
+
+    // add phenotype but without a sample S2
+    stoat::BinaryPhenotypeTable pheno(sample_to_index);
+    pheno.set_value_for_sample("S1", 1);
+    pheno.set_value_for_sample("S3", 0);
+    pheno.set_value_for_sample("S4", 0);
+    pheno.set_value_for_sample("S5", 1);
+    pheno.add_missing_sample_index(1);
+    
+    // link to them in the GenotypeTable
+    table.link_to_binary_phenotype(pheno);
+
+    SECTION("Table is the right size before removing non-covered samples") {
+        REQUIRE(table.get_n_active_samples() == 5);
+    }
+
+    SECTION("Table is the right size after removing non-covered samples") {
+        table.remove_noncovered_samples();
+        REQUIRE(table.get_n_active_samples() == 4);
+    }
+
+    SECTION("Table is the right size when covariates are missing") {
+        // S3 is also missing now
+        std::unordered_map<std::string, size_t> covar_to_index = {{"covar1", 0}};
+        stoat::CovariateTable covar(sample_to_index, covar_to_index);
+        covar.set_value_for_sample_and_feature("S1", "covar1", 0.2);
+        covar.set_value_for_sample_and_feature("S4", "covar1", 5);
+        covar.set_value_for_sample_and_feature("S5", "covar1", 11);
+        covar.add_missing_sample_index(1);
+        covar.add_missing_sample_index(2);
+
+        // link to them in the GenotypeTable
+        table.link_to_covariates(covar);
+        table.remove_noncovered_samples();
+        REQUIRE(table.get_n_active_samples() == 3);
+    }
+    
 }
 


### PR DESCRIPTION
## PR Log Entry
Whoever merges this PR should copy the following bullet points to the [PR Log](https://github.com/Pa-Tou/stoat/wiki/PR-Log):

 * Bug fix: mask samples that are missing from the phenotype/covariate files

## Description

Our SnarlDataCollection and Tables (genotype, phenotype, covariable) use the same *sample to index* map. When some samples are in the genotype/collection but not in the phenotype or covariable, we had noticed issues where the missing samples were still tested because they sometimes got assigned with a "default" phenotype. 

To handle those cases, we now mask missing samples at the same time as we mask samples that don't traverse the snarl of interest. 

In practice, I added a set to our Tables, to record which sample index are missing. We fill this information after parsing the files, at the same time as when we counted those missing samples for the log. Later, when genotypes and phenotypes are combined, the existing function to mask samples was updated to simply loop through this set and mask those additionnal samples.