### PR TITLE
Length bug

### DIFF
--- a/src/feature_tables.cpp
+++ b/src/feature_tables.cpp
@@ -492,6 +492,26 @@ void GenotypeTable::fill_contingency_table(std::vector<size_t>& g0, std::vector<
     }
 }
 
+std::vector<bool> GenotypeTable::get_active_alleles() const {
+    std::vector<bool> alleles(n_alleles, false);
+
+    // Go through all alleles and samples, skipping anything masked
+    for (size_t al_i = 0; al_i < n_alleles; al_i++) {
+        if (col_mask[al_i]) {continue;}
+        for (size_t samp_i = 0; samp_i < n_samples; samp_i++) {
+            if (row_mask[samp_i]) {continue;}
+
+            double value_sample = get_value(samp_i, al_i);
+            if (value_sample > 0){
+                alleles[al_i] = true;
+                //break out of the inner per-sample loop 
+                break;
+            }
+        }
+    }
+    return alleles;
+}
+
 // JEAN maybe these won't be used in the end. Remove at the end if not
 size_t GenotypeTable::get_n_active_alleles() const {
     return n_active_alleles;

--- a/src/feature_tables.cpp
+++ b/src/feature_tables.cpp
@@ -495,19 +495,9 @@ void GenotypeTable::fill_contingency_table(std::vector<size_t>& g0, std::vector<
 std::vector<bool> GenotypeTable::get_active_alleles() const {
     std::vector<bool> alleles(n_alleles, false);
 
-    // Go through all alleles and samples, skipping anything masked
+    // This is the reverse of the mask
     for (size_t al_i = 0; al_i < n_alleles; al_i++) {
-        if (col_mask[al_i]) {continue;}
-        for (size_t samp_i = 0; samp_i < n_samples; samp_i++) {
-            if (row_mask[samp_i]) {continue;}
-
-            double value_sample = get_value(samp_i, al_i);
-            if (value_sample > 0){
-                alleles[al_i] = true;
-                //break out of the inner per-sample loop 
-                break;
-            }
-        }
+        alleles[al_i] = !col_mask[al_i];
     }
     return alleles;
 }

--- a/src/feature_tables.hpp
+++ b/src/feature_tables.hpp
@@ -244,6 +244,9 @@ public:
     // JEAN maybe more efficient to keep track of this instead of recomputing from the mask each time?
     size_t get_n_active_alleles() const;
 
+    // Which alleles are used (true) or not used (false)?
+    std::vector<bool> get_active_alleles() const;
+
     /// this will include alleles, covariates, and the total allele count if it was added by add_total_allele_count_covariable
     size_t get_n_active_columns() const;
     size_t get_n_active_samples() const;

--- a/src/snarl_analyzer.cpp
+++ b/src/snarl_analyzer.cpp
@@ -157,6 +157,9 @@ bool BinarySnarlAnalyzer::test_and_write_snarl(stoat::snarl_info_t &snarl_data, 
     snarl_data.genotypes.remove_noncovered_samples();
     snarl_data.genotypes.remove_constant_predictors();
 
+    // Which alleles are actually used? Used for making sure that we only write the alleles we used
+    std::vector<bool> active_alleles = snarl_data.genotypes.get_active_alleles();
+
     // prepare an output objet and init to NA
     test_result_t test_res;
     test_res.pv = std::nan("");
@@ -185,7 +188,7 @@ bool BinarySnarlAnalyzer::test_and_write_snarl(stoat::snarl_info_t &snarl_data, 
         return true;
     }
     
-    out_writer.write_binary(snarl_data, test_res);
+    out_writer.write_binary(snarl_data, test_res, active_alleles);
     return false;
 }
 
@@ -230,7 +233,7 @@ bool ExactBinarySnarlAnalyzer::test_and_write_snarl(stoat::snarl_info_t &snarl_d
         return true;
     }
     
-    out_writer.write_binary(snarl_data, test_res);
+    out_writer.write_binary(snarl_data, test_res, snarl_data.genotypes.get_active_alleles());
     return false;
 }
     
@@ -247,6 +250,9 @@ bool BinaryCovarSnarlAnalyzer::test_and_write_snarl(stoat::snarl_info_t &snarl_d
     // prepare an output objet and init to NA
     test_result_t test_res;
     test_res.pv = std::nan("");
+
+    // Which alleles are actually used? Used for making sure that we only write the alleles we used
+    std::vector<bool> active_alleles;
     
     // should we test this snarl?
     if (snarl_data.genotypes.passes_filters(maf_threshold, min_individuals)){
@@ -258,6 +264,7 @@ bool BinaryCovarSnarlAnalyzer::test_and_write_snarl(stoat::snarl_info_t &snarl_d
     
         // before performing the regression, try to reduce potential colinearity
         snarl_data.genotypes.remove_duplicated_predictors();    
+        active_alleles = snarl_data.genotypes.get_active_alleles();
         snarl_data.genotypes.remove_one_allele();
     
         // prepare the matrices, fit the logistic model and test effect of alleles
@@ -273,7 +280,7 @@ bool BinaryCovarSnarlAnalyzer::test_and_write_snarl(stoat::snarl_info_t &snarl_d
         return true;
     }
  
-    out_writer.write_binary_covar(snarl_data, test_res);
+    out_writer.write_binary_covar(snarl_data, test_res, active_alleles);
     return false;
 }
 
@@ -292,6 +299,9 @@ bool QuantitativeSnarlAnalyzer::test_and_write_snarl(stoat::snarl_info_t &snarl_
     test_result_t test_res;
     test_res.pv = std::nan("");
 
+    // Which alleles are actually used? Used for making sure that we only write the alleles we used
+    std::vector<bool> active_alleles;
+
     // should we test this snarl?
     if (snarl_data.genotypes.passes_filters(maf_threshold, min_individuals)){
         // add the allele path info to include in the output
@@ -302,6 +312,7 @@ bool QuantitativeSnarlAnalyzer::test_and_write_snarl(stoat::snarl_info_t &snarl_
 
         // before performing the regression, try to reduce potential colinearity
         snarl_data.genotypes.remove_duplicated_predictors();
+        active_alleles = snarl_data.genotypes.get_active_alleles();
         snarl_data.genotypes.remove_one_allele();
 
         Eigen::MatrixXd X = snarl_data.genotypes.make_matrixXd_features();
@@ -318,7 +329,7 @@ bool QuantitativeSnarlAnalyzer::test_and_write_snarl(stoat::snarl_info_t &snarl_
         return true;
     }
  
-    out_writer.write_quantitative(snarl_data, test_res);
+    out_writer.write_quantitative(snarl_data, test_res, active_alleles);
     return false;
 }
 
@@ -353,6 +364,9 @@ bool EQTLSnarlAnalyzer::test_and_write_snarl(stoat::snarl_info_t &snarl_data, st
         test_result_t test_res;
         test_res.pv = std::nan("");
 
+    // Which alleles are actually used? Used for making sure that we only write the alleles we used
+        std::vector<bool> active_alleles;
+
         // should we test this snarl?
         if (snarl_data.genotypes.passes_filters(maf_threshold, min_individuals)){
 
@@ -364,6 +378,7 @@ bool EQTLSnarlAnalyzer::test_and_write_snarl(stoat::snarl_info_t &snarl_data, st
 
             // before performing the regression, try to reduce potential colinearity
             snarl_data.genotypes.remove_duplicated_predictors();
+            active_alleles = snarl_data.genotypes.get_active_alleles();
             snarl_data.genotypes.remove_one_allele();
     
             Eigen::MatrixXd X = snarl_data.genotypes.make_matrixXd_features();
@@ -380,7 +395,7 @@ bool EQTLSnarlAnalyzer::test_and_write_snarl(stoat::snarl_info_t &snarl_data, st
             continue;
         }
   
-        out_writer.write_eqtl(snarl_data, gene_name, test_res);
+        out_writer.write_eqtl(snarl_data, gene_name, test_res, active_alleles);
 
         // at least this test was not filtered
         filtered = false;

--- a/src/subcommand/vcf.cpp
+++ b/src/subcommand/vcf.cpp
@@ -88,7 +88,7 @@ int main_stoat_vcf(int argc, char* argv[]) {
         {0, 0, 0, 0}
     };
 
-    while ((c = getopt_long(argc, argv, "v:s:g:d:R:i:y:l:ft:V:o:uah", long_options, nullptr)) != -1) {
+    while ((c = getopt_long(argc, argv, "v:s:g:d:r:R:i:y:l:ft:V:o:uah", long_options, nullptr)) != -1) {
         switch (c) {
             case 'v': vcf_path = optarg; stoat_vcf::check_file(vcf_path); break;
             case 's': snarl_path = optarg; stoat_vcf::check_file(snarl_path); break;

--- a/src/writer.cpp
+++ b/src/writer.cpp
@@ -129,7 +129,7 @@ void Writer::write_stoat_output_header(stoat::phenotype_type_t phenotype_type) {
     }
 }
 
-void Writer::write_binary(const stoat::snarl_info_t& snarl_data, const stoat::test_result_t& test_result) {
+void Writer::write_binary(const stoat::snarl_info_t& snarl_data, const stoat::test_result_t& test_result, const std::vector<bool>& active_alleles) {
     // snarl information
     std::string outl = snarl_data.ref_path;
     outl += "\t" + std::to_string(snarl_data.start_position) + "\t" + std::to_string(snarl_data.end_position);
@@ -139,7 +139,7 @@ void Writer::write_binary(const stoat::snarl_info_t& snarl_data, const stoat::te
         //TODO: This writes "NA" if there are no paths/path lengths for the alleles. idk if this is what we want to do
         outl += "\tNA";
     } else {
-        outl += "\t" + stoat::vectorPathToString(snarl_data.walks_by_allele, true);
+        outl += "\t" + stoat::vectorPathToString(snarl_data.walks_by_allele, true, active_alleles);
     }
     // pvalues and contingency table
     outl += "\t" + stoat::set_precision(test_result.pv) + "\t" + stoat::set_precision(test_result.second_pv) + "\t" + test_result.group_paths + "\t" +
@@ -148,7 +148,7 @@ void Writer::write_binary(const stoat::snarl_info_t& snarl_data, const stoat::te
     write(outl);
 }
 
-void Writer::write_quantitative(const snarl_info_t& snarl_data, const stoat::test_result_t& test_result) {
+void Writer::write_quantitative(const snarl_info_t& snarl_data, const stoat::test_result_t& test_result, const std::vector<bool>& active_alleles) {
     // snarl information
     std::string outl = snarl_data.ref_path;
     outl += "\t" + std::to_string(snarl_data.start_position) + "\t" + std::to_string(snarl_data.end_position);
@@ -158,7 +158,7 @@ void Writer::write_quantitative(const snarl_info_t& snarl_data, const stoat::tes
         //TODO: This writes "NA" if there are no paths/path lengths for the alleles. idk if this is what we want to do
         outl += "\tNA";
     } else {
-        outl += "\t" + stoat::vectorPathToString(snarl_data.walks_by_allele, true);
+        outl += "\t" + stoat::vectorPathToString(snarl_data.walks_by_allele, true, active_alleles);
     }
     // pvalues and contingency table
     outl += "\t" + stoat::set_precision(test_result.pv) + "\t" + test_result.allele_paths + "\t" + std::to_string(snarl_data.depth) + "\n";
@@ -166,12 +166,12 @@ void Writer::write_quantitative(const snarl_info_t& snarl_data, const stoat::tes
     write(outl);
 }
 
-void Writer::write_binary_covar(const snarl_info_t& snarl_data, const stoat::test_result_t& test_result) {
+void Writer::write_binary_covar(const snarl_info_t& snarl_data, const stoat::test_result_t& test_result, const std::vector<bool>& active_alleles) {
     // now it's the same output
-    write_quantitative(snarl_data, test_result);
+    write_quantitative(snarl_data, test_result, active_alleles);
 }
 
-void Writer::write_eqtl(const snarl_info_t& snarl_data, const std::string& gene_name, const stoat::test_result_t& test_result) {
+void Writer::write_eqtl(const snarl_info_t& snarl_data, const std::string& gene_name, const stoat::test_result_t& test_result, const std::vector<bool>& active_alleles) {
     // snarl information
     std::string outl = snarl_data.ref_path;
     outl += "\t" + std::to_string(snarl_data.start_position) + "\t" + std::to_string(snarl_data.end_position);
@@ -181,7 +181,7 @@ void Writer::write_eqtl(const snarl_info_t& snarl_data, const std::string& gene_
         //TODO: This writes "NA" if there are no paths/path lengths for the alleles. idk if this is what we want to do
         outl += "\tNA";
     } else {
-        outl += "\t" + stoat::vectorPathToString(snarl_data.walks_by_allele, true);
+        outl += "\t" + stoat::vectorPathToString(snarl_data.walks_by_allele, true, active_alleles);
     }
     // pvalues and contingency table
     outl += "\t" + gene_name + "\t" + stoat::set_precision(test_result.pv) + "\t" + test_result.allele_paths + "\t" + std::to_string(snarl_data.depth) + "\n";

--- a/src/writer.hpp
+++ b/src/writer.hpp
@@ -30,13 +30,13 @@ public:
     void write_stoat_output_header(phenotype_type_t phenotype_type);
 
     // stoat output writers
-    void write_binary(const stoat::snarl_info_t& snarl_data, const stoat::test_result_t& test_result);
+    void write_binary(const stoat::snarl_info_t& snarl_data, const stoat::test_result_t& test_result, const std::vector<bool>& active_alleles);
 
-    void write_binary_covar(const snarl_info_t& snarl_data, const stoat::test_result_t& test_result);
+    void write_binary_covar(const snarl_info_t& snarl_data, const stoat::test_result_t& test_result, const std::vector<bool>& active_alleles);
 
-    void write_quantitative(const snarl_info_t& snarl_data, const stoat::test_result_t& test_result);
+    void write_quantitative(const snarl_info_t& snarl_data, const stoat::test_result_t& test_result, const std::vector<bool>& active_alleles);
 
-    void write_eqtl(const snarl_info_t& snarl_data, const std::string& gene_name, const stoat::test_result_t& test_result);
+    void write_eqtl(const snarl_info_t& snarl_data, const std::string& gene_name, const stoat::test_result_t& test_result, const std::vector<bool>& active_alleles);
     
 protected:
     const std::string file_path;

--- a/tests/system/test_simu_test.cpp
+++ b/tests/system/test_simu_test.cpp
@@ -8,7 +8,7 @@ namespace fs = std::filesystem;
 using namespace std;
 // TODO: Add vcf tests. This just copies the stats part of the old graph test
 
-TEST_CASE("Giant unverified binary association tests graph", "[graph]") {
+TEST_CASE("Giant unverified binary association tests graph", "[test]") {
 
     // Just check that this runs and produces some output
     const std::string output_dir = "../output_binary";
@@ -98,7 +98,7 @@ TEST_CASE("Giant unverified binary association tests graph", "[graph]") {
     clean_output_dir(output_dir);
 }
 
-TEST_CASE("Output simple nested chain", "[graph]") {
+TEST_CASE("Output simple nested chain", "[test]") {
     const std::string output_dir = "../output_binary";
     const std::string graph_base = "../tests/test_data/test_graphs/simple_nested_chain";
     const std::string samples_file = "./samples.tsv";
@@ -358,7 +358,7 @@ TEST_CASE("Output simple nested chain", "[graph]") {
     fs::remove(samples_file);
 }
 
-TEST_CASE("Output simple nested chain gbz", "[graph]") {
+TEST_CASE("Output simple nested chain gbz", "[test]") {
     const std::string output_dir = "../output_binary";
     const std::string graph_base = "../tests/test_data/test_graphs/simple_nested_chain";
     const std::string samples_file = "./samples.tsv";
@@ -688,7 +688,7 @@ TEST_CASE("Output simple nested chain gbz", "[graph]") {
     fs::remove(samples_file);
 }
 
-TEST_CASE("Output loop with snarl", "[graph]") {
+TEST_CASE("Output loop with snarl", "[test]") {
     const std::string output_dir = "../output_binary";
     const std::string graph_base = "../tests/test_data/test_graphs/loop_with_indel";
 
@@ -864,7 +864,7 @@ TEST_CASE("Output loop with snarl", "[graph]") {
     clean_output_dir(output_dir);
 }
 
-TEST_CASE("Multiple connected components", "[graph]") {
+TEST_CASE("Multiple connected components", "[test]") {
    /*
     This graph is duplicated twice 
                        5
@@ -967,3 +967,105 @@ TEST_CASE("Multiple connected components", "[graph]") {
     clean_output_dir(output_dir);
 }
 
+TEST_CASE("Simple bubble with three alleles and colinearity", "[test]") {
+
+    const std::string output_dir = "../output_binary";
+    const std::string graph_base = "../tests/test_data/test_graphs/simple_bubble";
+
+    const std::string samples_file = "./samples.tsv";
+    std::string vcf_filename = "./test.vcf";
+
+    std::ofstream vcf_out;
+    vcf_out.open(vcf_filename);
+    vcf_out << "##fileformat=VCFv4.2" << std::endl;
+    vcf_out << "##FILTER=<ID=PASS,Description=\"All filters passed\">" << std::endl;
+    vcf_out << "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">" << std::endl;
+    vcf_out << "##INFO=<ID=LV,Number=1,Type=Integer,Description=\"Level in the snarl tree (0=top level)\">" << std::endl;
+    vcf_out << "##INFO=<ID=AT,Number=R,Type=String,Description=\"Allele Traversal as path in graph\">" << std::endl;
+    vcf_out << "##contig=<ID=path0#0#path0,length=100>" << std::endl;
+    vcf_out << "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tsamp1\tsamp2\tsamp3\tsamp4" << std::endl;
+    vcf_out << "path0\t0\t>1>5\tCGT\tCCT,A\t60\t.\tLV=0;AT=>1>2>5,>1>3>5,>1>4>5\tGT\t0/0\t0/1\t1/1\t0/1" << std::endl;
+    vcf_out.close();
+
+
+    std::vector<std::string> samples_of_interest = {"samp1", "samp2"};
+    std::vector<std::string> other_samples = {"samp3", "samp4"};
+
+    std::string write_cmd = "echo \"SAMPLE\tPHENO\" > " + samples_file;
+    int ignore = std::system(write_cmd.c_str());
+    for (auto sample : samples_of_interest) {
+        write_cmd = "echo \"" + sample + "\t1\" >> " + samples_file;
+        ignore = std::system(write_cmd.c_str());
+    }
+    for (auto sample : other_samples) {
+        write_cmd = "echo \"" + sample + "\t0\" >> " + samples_file;
+        ignore = std::system(write_cmd.c_str());
+    }
+
+
+    SECTION("Test chi2 tsv output") {
+
+        clean_output_dir(output_dir);
+
+        std::string cmd = "../bin/stoat vcf -u";
+           cmd += " -g " + graph_base + ".hg"
+            + " -d " + graph_base + ".dist"
+            + " -v " + vcf_filename
+            + " -r path0"
+            + " --output " + output_dir;
+
+        std::cout << "Command run : \n" << cmd << std::endl;
+
+        int command_output = std::system(cmd.c_str());
+        if (command_output != 0) {
+            std::cerr << "Command failed: " << cmd << "\n";
+            REQUIRE( false);
+        }
+        
+        std::string cmd_test = "../bin/stoat test -u";
+        cmd_test += " -g " + output_dir + "/snarl_genotypes.tsv"
+            + " -p " + samples_file
+            + " -m chi2"
+            + " --output " + output_dir;
+
+        std::cout << "Command run : \n" << cmd_test << std::endl;
+
+        command_output = std::system(cmd_test.c_str());
+        if (command_output != 0) {
+            std::cerr << "Command failed: " << cmd_test << "\n";
+            REQUIRE( false);
+        }
+
+        REQUIRE(std::filesystem::exists(output_dir+"/stoat.assoc.pvalues.tsv"));
+
+        binary_table_values_t truth1 ({(std::string)"path0", 
+                                  (size_t)10, 
+                                  (size_t)11, 
+                                  std::make_pair<std::string, std::string>(">1","<5"), 
+                                  std::vector<std::string>({"1","1"}),
+                                  (std::string) "0.4857",
+                                  (std::string) "0.1573", 
+                                  std::vector<std::string>({"3:1","1:3"}), 
+                                  (size_t)1});
+
+        ifstream in_table;
+        in_table.open(output_dir+"/stoat.assoc.pvalues.tsv");
+        std::string line; 
+        std::getline(in_table, line); // Header
+        std::vector<bool> found_snarls (1, false);
+        while (std::getline(in_table, line)) {
+            binary_table_values_t test = load_binary_snarl_line(line);
+            cerr << "LINE: " << line << endl;
+            if (test == truth1) {
+                found_snarls[0] = true;
+            }
+        }
+        in_table.close();
+        REQUIRE(found_snarls[0]);
+
+    }
+
+    fs::remove(samples_file);
+    fs::remove(vcf_filename);
+    clean_output_dir(output_dir);
+}

--- a/tests/unittest/feature_tables_unit.cpp
+++ b/tests/unittest/feature_tables_unit.cpp
@@ -243,6 +243,11 @@ TEST_CASE( "Combined GenotypeTable", "[table]" ) {
         REQUIRE(table.get_n_active_alleles() == 4);
         REQUIRE(table.get_n_active_columns() == 5);
         REQUIRE(table.get_n_active_samples() == 6);
+        std::vector<bool> active_alleles = table.get_active_alleles();
+        REQUIRE(active_alleles[0]);
+        REQUIRE(active_alleles[1]);
+        REQUIRE(active_alleles[2]);
+        REQUIRE(active_alleles[3]);
     }
 
     SECTION("Accessor works on alleles and covariates") {
@@ -259,18 +264,33 @@ TEST_CASE( "Combined GenotypeTable", "[table]" ) {
         table.remove_constant_predictors();
         REQUIRE(table.get_n_active_alleles() == 3);
         REQUIRE(table.get_n_active_columns() == 4);
+        std::vector<bool> active_alleles = table.get_active_alleles();
+        REQUIRE(active_alleles[0]);
+        REQUIRE(!active_alleles[1]);
+        REQUIRE(active_alleles[2]);
+        REQUIRE(active_alleles[3]);
     }
 
     SECTION("Remove first allele") {
         table.remove_one_allele();
         REQUIRE(table.get_n_active_alleles() == 3);
         REQUIRE(table.get_n_active_columns() == 4);
+        std::vector<bool> active_alleles = table.get_active_alleles();
+        REQUIRE(!active_alleles[0]);
+        REQUIRE(active_alleles[1]);
+        REQUIRE(active_alleles[2]);
+        REQUIRE(active_alleles[3]);
     }
 
     SECTION("Remove duplicated predictor") {
         table.remove_duplicated_predictors();
         REQUIRE(table.get_n_active_alleles() == 3);
         REQUIRE(table.get_n_active_columns() == 4);
+        std::vector<bool> active_alleles = table.get_active_alleles();
+        REQUIRE(active_alleles[0]);
+        REQUIRE(active_alleles[1]);
+        REQUIRE((active_alleles[2] || active_alleles[3]));
+        REQUIRE(((!active_alleles[2]) || (!active_alleles[3])));
     }
 
     SECTION("Add new total allele count column") {


### PR DESCRIPTION
Check which alleles are used by the GenotypeTable before printing the lengths to the final output.
This addresses #38 

@jmonlong is the `col_mask` the only way we drop alleles? There wouldn't be another reason for the alleles we save as paths to not match the counts of alleles we output?