### PR TITLE
Empty matrix bug

### DIFF
--- a/src/feature_tables.cpp
+++ b/src/feature_tables.cpp
@@ -381,12 +381,14 @@ void GenotypeTable::remove_constant_predictors() {
         // compare each value with the first value
         double first_value;
         bool constant = false;
+        bool has_any_allele;
         for (size_t row_ii = 0; row_ii < n_samples; row_ii++) {
 
             // skip if already masked
             if (row_mask[row_ii]) {
                 continue;
             }
+            has_any_allele = true;
 
             // if first value to consider, save it
             if (!constant) {
@@ -399,6 +401,9 @@ void GenotypeTable::remove_constant_predictors() {
                 constant = false;
                 break;
             }
+        }
+        if (!has_any_allele) {
+            constant = true;
         }
 
         // mask if constant

--- a/src/feature_tables.cpp
+++ b/src/feature_tables.cpp
@@ -381,7 +381,7 @@ void GenotypeTable::remove_constant_predictors() {
         // compare each value with the first value
         double first_value;
         bool constant = false;
-        bool has_any_allele;
+        bool has_any_allele = false;
         for (size_t row_ii = 0; row_ii < n_samples; row_ii++) {
 
             // skip if already masked

--- a/src/snarl_analyzer.cpp
+++ b/src/snarl_analyzer.cpp
@@ -325,7 +325,15 @@ bool QuantitativeSnarlAnalyzer::test_and_write_snarl(stoat::snarl_info_t &snarl_
         snarl_data.genotypes.remove_one_allele();
 
         Eigen::MatrixXd X = snarl_data.genotypes.make_matrixXd_features();
+        if (X.size() == 0) {
+            stoat::LOG_DEBUG("Filtered: Genotype matrix is empty");
+            return true;
+        }
         Eigen::VectorXd Y = snarl_data.genotypes.make_vectorxd_phenotype();
+        if (Y.size() == 0) {
+            stoat::LOG_DEBUG("Filtered: Phenotype matrix is empty");
+            return true;
+        }
 
         test_res.pv = lr.linear_regression(X, Y, snarl_data.genotypes.get_n_active_alleles());
     } else {
@@ -391,7 +399,15 @@ bool EQTLSnarlAnalyzer::test_and_write_snarl(stoat::snarl_info_t &snarl_data, st
             snarl_data.genotypes.remove_one_allele();
     
             Eigen::MatrixXd X = snarl_data.genotypes.make_matrixXd_features();
+            if (X.size() == 0) {
+                stoat::LOG_DEBUG("Filtered: Genotype matrix is empty");
+                continue;
+            }
             Eigen::VectorXd Y = snarl_data.genotypes.make_vectorxd_phenotype();
+            if (Y.size() == 0) {
+                stoat::LOG_DEBUG("Filtered: Phenotype matrix is empty");
+                continue;
+            }
 
             test_res.pv = lr.linear_regression(X, Y, snarl_data.genotypes.get_n_active_alleles());
         } else {

--- a/src/snarl_analyzer.cpp
+++ b/src/snarl_analyzer.cpp
@@ -269,7 +269,16 @@ bool BinaryCovarSnarlAnalyzer::test_and_write_snarl(stoat::snarl_info_t &snarl_d
     
         // prepare the matrices, fit the logistic model and test effect of alleles
         Eigen::MatrixXd X = snarl_data.genotypes.make_matrixXd_features();
+        if (X.size() == 0) {
+            stoat::LOG_DEBUG("Filtered: Genotype matrix is empty");
+            return true;
+        }
+
         Eigen::VectorXd Y = snarl_data.genotypes.make_vectorxd_phenotype();
+        if (Y.size() == 0) {
+            stoat::LOG_DEBUG("Filtered: Phenotype matrix is empty");
+            return true;
+        }
         test_res.pv = lr.logistic_regression(X, Y, snarl_data.genotypes.get_n_active_alleles());
     } else {
         stoat::LOG_DEBUG("Filtered: didn't pass the filters");

--- a/src/subcommand/test.cpp
+++ b/src/subcommand/test.cpp
@@ -30,7 +30,7 @@ void print_help_test() {
               << "  -w, --max-gene-distance INT     Include snarls up to this distance from the gene when looking for eQTLs [1000000]\n"
               << "  -c, --covariate FILE            Path to the covariate file\n"
               << "  -C, --covar-name NAME           Covariate column name(s) used\n"
-              << "  -I, --min-individuals INT       Minimum number of individuals per snarl [0]\n"
+              << "  -I, --min-individuals INT       Minimum number of individuals per snarl [2]\n"
               << "  -M, --maf FLOAT                 Minimum allele frequency threshold [0.05]\n"
               //<< "  -t, --threads INT               Number of threads to use [1]\n"
               << "  -V, --verbose INT               Verbosity level (0=error, 1=warn, 2=info, 3=debug, 4=trace) [2]\n"
@@ -49,7 +49,7 @@ int main_stoat_test(int argc, char* argv[]) {
 
     // default value for the filter thresholds
     double maf_threshold = 0.05;
-    size_t min_individuals = 0;
+    size_t min_individuals = 2;
     size_t max_gene_dist = 1000000;
 
     // which method to use

--- a/tests/system/test_simu_test.cpp
+++ b/tests/system/test_simu_test.cpp
@@ -1069,3 +1069,104 @@ TEST_CASE("Simple bubble with three alleles and colinearity", "[test]") {
     fs::remove(vcf_filename);
     clean_output_dir(output_dir);
 }
+
+
+TEST_CASE("Don't do anything when there are no samples", "[test]") {
+/*
+                        6
+                      /   \
+             2       5 ----7    9
+           /   \   /         \ /  \
+         1       4  ----------8---10
+           \   /
+             3
+
+*/
+
+
+    const std::string output_dir = "../output_binary";
+    const std::string graph_base = "../tests/test_data/test_graphs/simple_nested_chain";
+    const std::string samples_filename = "./samples.tsv";
+    const std::string reference_filename = "./references.tsv";
+    std::string vcf_filename = "./test.vcf";
+
+    std::ofstream vcf_out;
+    vcf_out.open(vcf_filename);
+    vcf_out << "##fileformat=VCFv4.2" << std::endl;
+    vcf_out << "##FILTER=<ID=PASS,Description=\"All filters passed\">" << std::endl;
+    vcf_out << "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">" << std::endl;
+    vcf_out << "##INFO=<ID=LV,Number=1,Type=Integer,Description=\"Level in the snarl tree (0=top level)\">" << std::endl;
+    vcf_out << "##INFO=<ID=AT,Number=R,Type=String,Description=\"Allele Traversal as path in graph\">" << std::endl;
+    vcf_out << "##contig=<ID=path0#0#path0,length=100>" << std::endl;
+    vcf_out << "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS1\tS2" << std::endl;
+    vcf_out << "path0#0#path0\t0\t>1>4\tCGT\tCCT,A\t60\t.\tLV=0;AT=>1>2>4,>1>3>4\tGT\t./.\t1/1" << std::endl;
+    vcf_out << "path0#0#path0\t3\t>4>8\tCGT\tCCT,A\t60\t.\tLV=0;AT=>4>5>6>7>8,>4>5>7>8,>4>8\tGT\t./.\t./." << std::endl;
+    vcf_out.close();
+
+
+    // Only S1, S2 will get ignored
+    std::string write_cmd = "echo \"SAMPLE\tPHENO\" > " + samples_filename;
+    int ignore = std::system(write_cmd.c_str());
+    write_cmd = (std::string) "echo \"" + "S1" + "\t1\" >> " + samples_filename;
+    ignore = std::system(write_cmd.c_str());
+
+    // Write the reference file
+    write_cmd = "echo path0#0#path0 > " + reference_filename;
+    ignore = std::system(write_cmd.c_str());
+
+    SECTION("Test without untangling") {
+        // Make the snarl file
+
+        std::string cmd = (std::string)"../bin/stoat vcf -u"
+            + " -g " + graph_base + ".hg"
+            + " -d " + graph_base + ".dist"
+            + " -R " + reference_filename
+            + " -v " + vcf_filename
+            + " -o " + output_dir;
+        std::cerr << "Run command " << cmd << std::endl;
+        int command_output = std::system(cmd.c_str());
+
+        if (command_output != 0) {
+            std::cerr << "Command failed: " << cmd << "\n";
+            REQUIRE(false);
+        }
+
+        std::string cmd_test = "../bin/stoat test -u";
+        cmd_test += " -g " + output_dir + "/snarl_genotypes.tsv"
+            + " -p " + samples_filename
+            + " -m logreg"
+            + " --output " + output_dir;
+
+        std::cout << "Command run : \n" << cmd_test << std::endl;
+
+        command_output = std::system(cmd_test.c_str());
+        if (command_output != 0) {
+            std::cerr << "Command failed: " << cmd_test << "\n";
+            REQUIRE( false);
+        }
+
+        // Snarls should now be in output_dir/snarl_info.tsv
+        // Genotypes should be in output_dir/snarl_genotypes.tsv
+        // Final values should be in output_dir/stoat.assoc.pvalues.tsv
+        REQUIRE(std::filesystem::exists(output_dir+"/stoat.assoc.pvalues.tsv"));
+
+        std::ifstream resultfile;
+        resultfile.open(output_dir+"/stoat.assoc.pvalues.tsv");
+        REQUIRE(resultfile.peek() != std::ifstream::traits_type::eof());
+
+        // There should be no snarls, only the header
+        std::string line;
+        while (std::getline(resultfile, line)) {
+            REQUIRE(line.at(0) == '#');
+        }
+        resultfile.close();
+        clean_output_dir(output_dir);
+    }
+    
+
+
+    clean_output_dir(output_dir);
+    fs::remove(samples_filename);
+    fs::remove(reference_filename);
+    fs::remove(vcf_filename);
+}


### PR DESCRIPTION
Fix bug where empty matrices would fail. This now checks for empty matrices and also fixes the underlying problem so that removing constant predictors also removes a predictor when all samples are empty.